### PR TITLE
Add local storage quiz management

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the files in the `quiz` folder for minimal working examples.
 
 ## ▶️ How to view the site
 
-Open `https://<USERNAME>.github.io/Toilet-Learn/` in your browser once the `gh-pages` branch is published.
+Open `https://mcdorians.github.io/Toilet-Learn/` in your browser once the `gh-pages` branch is published.
 
 ## 🛠 Local development
 


### PR DESCRIPTION
## Summary
- persist uploaded/pasted quizzes in browser storage
- display stored quizzes alongside built‑in ones
- prefix quiz choices to show origin
- update site URL in README

## Testing
- `npm install`
- `npx playwright install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4c8fc3d883319f280fd8ca995fc5