### PR TITLE
Fix gap-fill blank rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
 
         .hint { color: var(--accent-color); border-bottom: 1px dotted var(--accent-color); cursor: help; }
         .hint:hover { background-color: #eaf2f8; }
+        .blank { font-weight: bold; letter-spacing: 2px; }
 
         .hint-overlay {
             position: fixed; top: 0; left: 0; width: 100%; height: 100%;

--- a/js/app.js
+++ b/js/app.js
@@ -202,7 +202,12 @@
                 
                 this.updateProgressBar();
                 this.elements.questionCategory.textContent = q.category;
-                this.elements.questionText.innerHTML = q.questionText.replace('{blank}', '<span class="blank"></span>');
+                let qText = q.questionText;
+                if (qText.includes('{blank}')) {
+                    const replacement = q.type === 'gap-fill' ? '<span class="blank">_____</span>' : '';
+                    qText = qText.replace(/\{blank\}/g, replacement);
+                }
+                this.elements.questionText.innerHTML = qText;
                 
                 if (q.readingTextId && this.readingTextsMap.has(q.readingTextId)) {
                     this.elements.readingTextContainer.innerHTML = this.readingTextsMap.get(q.readingTextId);


### PR DESCRIPTION
## Summary
- ensure `{blank}` is replaced with underscores for gap-fill questions
- style `.blank` spans

## Testing
- `npm install`
- `npx playwright install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f72f5fb7c8331a93982b418a567ac