### PR TITLE
Make README links clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ See the files in the `quiz` folder for minimal working examples.
 
 ## ▶️ How to view the site
 
-Open `https://mcdorians.github.io/Toilet-Learn/` in your browser once the `gh-pages` branch is published.
+Open [https://mcdorians.github.io/Toilet-Learn/](https://mcdorians.github.io/Toilet-Learn/) in your browser once the `gh-pages` branch is published.
 
 ## 🛠 Local development
 
-Run a local server and open `http://localhost:3000/`:
+Run a local server and open [http://localhost:3000/](http://localhost:3000/):
 
 ```bash
 python3 -m http.server 3000


### PR DESCRIPTION
## Summary
- convert plaintext URLs to Markdown links for easier navigation

## Testing
- `npm install`
- `npx playwright install`
- `npx playwright install-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801a96182483319c90f4cdcc10d30b