### PR TITLE
Add German-language Japanese quizzes

### DIFF
--- a/quiz/german/japanese/grammar_drills_complete.json
+++ b/quiz/german/japanese/grammar_drills_complete.json
@@ -1,0 +1,385 @@
+{
+  "title": "Umfassender Grammatik-Drill (N5)",
+  "description": "Teste dein Wissen zu grundlegenden Partikeln, Orts- und Zeitangaben, Vorlieben und Dialogen. Diese Übung deckt alle Aufgaben von A bis E vollständig ab.",
+  "cssStyleAdditions": ":root { --primary-color: #2c3e50; --secondary-color: #16a085; } .quiz-option-button.long-text { font-size: 1.1em; }",
+  "questions": [
+    {
+      "id": "gram_a_1",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>にほんご</span> {blank} <span class='hint'>べんきょうします</span>。",
+      "options": ["を", "が", "は"],
+      "correctAnswer": "を",
+      "hints": ["nihongo", "benkyou shimasu"]
+    },
+    {
+      "id": "gram_a_2a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>あさ</span> {blank} <span class='hint'>コーヒーを のみます</span>。",
+      "options": ["は", "に", "で"],
+      "correctAnswer": "は",
+      "hints": ["asa", "koohii o nomimasu"]
+    },
+    {
+      "id": "gram_a_2b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>あさは コーヒー</span> {blank} <span class='hint'>のみます</span>。",
+      "options": ["を", "が", "に"],
+      "correctAnswer": "を",
+      "hints": ["asa wa koohii", "nomimasu"]
+    },
+    {
+      "id": "gram_a_3a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>しゅうまつ</span> {blank} <span class='hint'>ともだちと えいがを みます</span>。",
+      "options": ["は", "が", "で"],
+      "correctAnswer": "は",
+      "hints": ["shuumatsu", "tomodachi to eiga o mimasu"]
+    },
+    {
+      "id": "gram_a_3b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>しゅうまつは ともだち</span> {blank} <span class='hint'>えいがを みます</span>。",
+      "options": ["と", "に", "の"],
+      "correctAnswer": "と",
+      "hints": ["shuumatsu wa tomodachi", "eiga o mimasu"]
+    },
+    {
+      "id": "gram_a_4a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>わたし</span> {blank} <span class='hint'>にほんの せんせいです</span>。",
+      "options": ["は", "が", "も"],
+      "correctAnswer": "は",
+      "hints": ["watashi", "nihon no sensei desu"]
+    },
+    {
+      "id": "gram_a_4b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>わたしは にほん</span> {blank} <span class='hint'>せんせいです</span>。",
+      "options": ["の", "は", "で"],
+      "correctAnswer": "の",
+      "hints": ["watashi wa nihon", "sensei desu"]
+    },
+    {
+      "id": "gram_a_5",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>いま、コンビニ</span> {blank} <span class='hint'>パンを かいます</span>。",
+      "options": ["で", "に", "を"],
+      "correctAnswer": "で",
+      "hints": ["ima, konbini", "pan o kaimasu"]
+    },
+    {
+      "id": "gram_a_6a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>おかあさん</span> {blank} <span class='hint'>ケーキが すきです</span>。",
+      "options": ["は", "を", "に"],
+      "correctAnswer": "は",
+      "hints": ["okaasan", "keeki ga suki desu"]
+    },
+    {
+      "id": "gram_a_6b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>おかあさんは ケーキ</span> {blank} <span class='hint'>すきです</span>。",
+      "options": ["が", "を", "は"],
+      "correctAnswer": "が",
+      "hints": ["okaasan wa keeki", "suki desu"]
+    },
+    {
+      "id": "gram_a_7a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>あした</span> {blank} <span class='hint'>がっこうに いきます</span>。",
+      "options": ["は", "を", "で"],
+      "correctAnswer": "は",
+      "hints": ["ashita", "gakkou ni ikimasu"]
+    },
+    {
+      "id": "gram_a_7b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>あしたは がっこう</span> {blank} <span class='hint'>いきます</span>。",
+      "options": ["に", "で", "へ"],
+      "correctAnswer": "に",
+      "hints": ["ashita wa gakkou", "ikimasu"]
+    },
+    {
+      "id": "gram_a_8",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>これは わたし</span> {blank} <span class='hint'>ほんです</span>。",
+      "options": ["の", "は", "が"],
+      "correctAnswer": "の",
+      "hints": ["kore wa watashi", "hon desu"]
+    },
+    {
+      "id": "gram_a_9",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>としょかん</span> {blank} <span class='hint'>しゅくだいを します</span>。",
+      "options": ["で", "に", "を"],
+      "correctAnswer": "で",
+      "hints": ["toshokan", "shukudai o shimasu"]
+    },
+    {
+      "id": "gram_a_10a",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>いぬ</span> {blank} <span class='hint'>ねこの あいだに ねています</span>。",
+      "options": ["と", "は", "の"],
+      "correctAnswer": "と",
+      "hints": ["inu", "neko no aida ni neteimasu"]
+    },
+    {
+      "id": "gram_a_10b",
+      "category": "Übung A: Partikeln",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>いぬと ねこの あいだ</span> {blank} <span class='hint'>ねています</span>。",
+      "options": ["に", "で", "を"],
+      "correctAnswer": "に",
+      "hints": ["inu to neko no aida", "neteimasu"]
+    },
+    {
+      "id": "gram_b_1",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>ほんは つくえ</span> {blank} <span class='hint'>にあります</span>。",
+      "options": ["の うえ", "の した", "の なか"],
+      "correctAnswer": "の うえ",
+      "hints": ["hon wa tsukue", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_2",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>ねこは いす</span> {blank} <span class='hint'>にいます</span>。",
+      "options": ["の した", "の そと", "の となり"],
+      "correctAnswer": "の した",
+      "hints": ["neko wa isu", "ni imasu"]
+    },
+    {
+      "id": "gram_b_3",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>くるまは うち</span> {blank} <span class='hint'>にあります</span>。",
+      "options": ["の まえ", "の うしろ", "の あいだ"],
+      "correctAnswer": "の まえ",
+      "hints": ["kuruma wa uchi", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_4",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>テレビは ソファ</span> {blank} <span class='hint'>にあります</span>。",
+      "options": ["の うしろ", "の なか", "の うえ"],
+      "correctAnswer": "の うしろ",
+      "hints": ["terebi wa sofa", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_5",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>こうえんは がっこうと びょういん</span> {blank} <span class='hint'>にあります</span>。",
+      "options": ["の あいだ", "の となり", "の まえ"],
+      "correctAnswer": "の あいだ",
+      "hints": ["kouen wa gakkou to byouin", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_6",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>さいふは かばん</span> {blank} <span class='hint'>にあります</span>.",
+      "options": ["の なか", "の そと", "の した"],
+      "correctAnswer": "の なか",
+      "hints": ["saifu wa kaban", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_7",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>じてんしゃは うち</span> {blank} <span class='hint'>にあります</span>.",
+      "options": ["の そと", "の あいだ", "の うえ"],
+      "correctAnswer": "の そと",
+      "hints": ["jitensha wa uchi", "ni arimasu"]
+    },
+    {
+      "id": "gram_b_8",
+      "category": "Übung B: Positionen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>ぎんこうは ゆうびんきょく</span> {blank} <span class='hint'>にあります</span>.",
+      "options": ["の となり", "の なか", "の うしろ"],
+      "correctAnswer": "の となり",
+      "hints": ["ginkou wa yuubinkyoku", "ni arimasu"]
+    },
+    {
+      "id": "gram_c_1",
+      "category": "Übung C: Zeitangaben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>まいあさ</span> 7じ {blank} <span class='hint'>おきます</span>.",
+      "options": ["に", "ごろ", "から"],
+      "correctAnswer": "に",
+      "hints": ["maiasa", "okimasu"]
+    },
+    {
+      "id": "gram_c_2a",
+      "category": "Übung C: Zeitangaben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>しごと</span>は 9じ {blank} 5じ<span class='hint'>まで</span> です.",
+      "options": ["から", "は", "に"],
+      "correctAnswer": "から",
+      "hints": ["shigoto", "made"]
+    },
+    {
+      "id": "gram_c_2b",
+      "category": "Übung C: Zeitangaben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>しごと</span>は 9じ<span class='hint'>から</span> 5じ {blank} です.",
+      "options": ["まで", "は", "に"],
+      "correctAnswer": "まで",
+      "hints": ["shigoto", "kara"]
+    },
+    {
+      "id": "gram_c_3",
+      "category": "Übung C: Zeitangaben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>よる</span> 11じ {blank} <span class='hint'>ねます</span>.",
+      "options": ["ごろ", "に", "まで"],
+      "correctAnswer": "ごろ",
+      "hints": ["yoru", "nemasu"]
+    },
+    {
+      "id": "gram_c_4a",
+      "category": "Übung C: Zeitangaben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>きのう</span> {blank} 3じ<span class='hint'>から</span> 6じ<span class='hint'>まで</span> <span class='hint'>べんきょうしました</span>.",
+      "options": ["は", "が", "を"],
+      "correctAnswer": "は",
+      "hints": ["kinou", "kara", "made", "benkyou shimashita"]
+    },
+    {
+      "id": "gram_d_1",
+      "category": "Übung D: Vorlieben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>わたしは さかな</span> {blank} <span class='hint'>すきです</span>.",
+      "options": ["が", "を", "は"],
+      "correctAnswer": "が",
+      "hints": ["watashi wa sakana", "suki desu"]
+    },
+    {
+      "id": "gram_d_2",
+      "category": "Übung D: Häufigkeit",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>わたしは スポーツが あまり すきじゃ</span> {blank}.",
+      "options": ["ありません", "です", "ます"],
+      "correctAnswer": "ありません",
+      "hints": ["watashi wa supootsu ga amari sukija"]
+    },
+    {
+      "id": "gram_d_3",
+      "category": "Übung D: Vorlieben",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>わたしは コーヒーが</span> {blank}.",
+      "options": ["だいすきです", "すきじゃありません", "あまりすきです"],
+      "correctAnswer": "だいすきです",
+      "hints": ["watashi wa koohii ga"]
+    },
+    {
+      "id": "gram_d_4",
+      "category": "Übung D: Häufigkeit",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>にほんの えいがは</span> {blank} <span class='hint'>みません</span>.",
+      "options": ["ぜんぜん", "あまり", "よく"],
+      "correctAnswer": "ぜんぜん",
+      "hints": ["nihon no eiga wa", "mimasen"]
+    },
+    {
+      "id": "gram_d_5",
+      "category": "Übung D: Fragen",
+      "type": "gap-fill",
+      "questionText": "<span class='hint'>あなたは パンが</span> {blank}.",
+      "options": ["すきですか", "すきです", "すき"],
+      "correctAnswer": "すきですか",
+      "hints": ["anata wa pan ga"]
+    },
+    {
+      "id": "gram_e_1a",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "A: <span class='hint'>あした</span> {blank} <span class='hint'>どこに いきますか</span>.",
+      "options": ["は", "が", "を"],
+      "correctAnswer": "は",
+      "hints": ["ashita", "doko ni ikimasu ka"]
+    },
+    {
+      "id": "gram_e_1b",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "B: <span class='hint'>こうえん</span> {blank} <span class='hint'>いきます</span>.",
+      "options": ["に", "で", "を"],
+      "correctAnswer": "に",
+      "hints": ["kouen", "ikimasu"]
+    },
+    {
+      "id": "gram_e_2a",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "A: <span class='hint'>だれ</span> {blank} <span class='hint'>テニスをしますか</span>.",
+      "options": ["と", "に", "で"],
+      "correctAnswer": "と",
+      "hints": ["dare", "tenisu o shimasu ka"]
+    },
+    {
+      "id": "gram_e_2b",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "B: <span class='hint'>おっと</span> {blank} <span class='hint'>します</span>.",
+      "options": ["と", "を", "が"],
+      "correctAnswer": "と",
+      "hints": ["otto", "shimasu"]
+    },
+    {
+      "id": "gram_e_3a",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "A: <span class='hint'>どこ</span> {blank} <span class='hint'>ひるごはんを たべますか</span>.",
+      "options": ["で", "に", "を"],
+      "correctAnswer": "で",
+      "hints": ["doko", "hirugohan o tabemasu ka"]
+    },
+    {
+      "id": "gram_e_4a",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "A: <span class='hint'>こんばん</span> {blank} <span class='hint'>なにをしますか</span>.",
+      "options": ["は", "に", "で"],
+      "correctAnswer": "は",
+      "hints": ["konban", "nani o shimasu ka"]
+    },
+    {
+      "id": "gram_e_5a",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "A: <span class='hint'>いっしょに</span> <span class='hint'>しゅくだいを</span> し{blank}か.",
+      "options": ["ません", "ます", "ましょう"],
+      "correctAnswer": "ません",
+      "hints": ["issho ni", "shukudai o"]
+    },
+    {
+      "id": "gram_e_5b",
+      "category": "Übung E: Dialoge",
+      "type": "gap-fill",
+      "questionText": "B: <span class='hint'>いいですね</span>。<span class='hint'>としょかん</span> {blank} しましょう.",
+      "options": ["で", "に", "を"],
+      "correctAnswer": "で",
+      "hints": ["ii desu ne", "toshokan"]
+    }
+  ]
+}

--- a/quiz/german/japanese/hobbies.json
+++ b/quiz/german/japanese/hobbies.json
@@ -1,0 +1,119 @@
+{
+  "title": "Lehreinheit: Hobbys & Freizeit",
+  "description": "Lerne, umfassend über deine Hobbys und Aktivitäten an freien Tagen zu sprechen. Teste dein Wissen zu Vokabeln, Grammatik und Leseverständnis.",
+  "cssStyleAdditions": ":root { --primary-color: #e74c3c; --secondary-color: #34495e; }",
+  "readingTexts": [
+    {
+      "id": "yamada-text",
+      "content": "<p class='japanese-text'>山田さんの趣味はたくさんあります。山田さんは、料理をするのが好きです。でも、スポーツはあまり好きではありません。</p><p class='japanese-text'>休みの日は、たいていうちでゆっくりします。本を読んだり、音楽を聴いたりします。時々、友達と町で買い物をしたり、カフェで話したりします。山田さんは写真も撮ります。公園で、きれいな花や面白い人の写真を撮るのが好きです。</p>"
+    }
+  ],
+  "questions": [
+    {
+      "id": "hob_vok_1",
+      "category": "Vokabeln",
+      "type": "multiple-choice",
+      "questionText": "Was bedeutet das Wort <span class='hint'>建築</span>?",
+      "options": ["Architektur", "Musik", "Fotografie", "Sport"],
+      "correctAnswer": "Architektur",
+      "hints": ["kenchiku"]
+    },
+    {
+      "id": "hob_vok_2",
+      "category": "Vokabeln",
+      "type": "multiple-choice",
+      "questionText": "Welches Wort bedeutet „Einkaufen“?",
+      "options": ["<span class='hint'>料理</span> (りょうり)", "<span class='hint'>読書</span> (どくしょ)", "<span class='hint'>買い物</span> (かいもの)", "<span class='hint'>散歩</span> (さんぽ)"],
+      "correctAnswer": "<span class='hint'>買い物</span> (かいもの)",
+      "hints": ["ryouri", "dokusho", "kaimono", "sanpo"]
+    },
+    {
+      "id": "hob_vok_3",
+      "category": "Vokabeln",
+      "type": "multiple-choice",
+      "questionText": "Was ist ein <span class='hint'>休みの日</span>?",
+      "options": ["Ein Arbeitstag", "Ein Feiertag / Freier Tag", "Ein Geburtstag", "Ein Wochentag"],
+      "correctAnswer": "Ein Feiertag / Freier Tag",
+      "hints": ["yasumi no hi"]
+    },
+    {
+      "id": "hob_gram_1",
+      "category": "Grammatik: Partikel",
+      "type": "gap-fill",
+      "questionText": "アニメ {blank} <span class='hint'>好きです</span>。",
+      "options": ["が", "を", "は", "で"],
+      "correctAnswer": "が",
+      "hints": ["suki desu"]
+    },
+    {
+      "id": "hob_gram_2",
+      "category": "Grammatik: Vorlieben (Aktivität)",
+      "type": "multiple-choice",
+      "questionText": "Wie sagt man korrekt „Ich mag es, Fotos zu machen“?",
+      "options": ["<span class='hint'>写真を撮るのが好きです</span>", "<span class='hint'>写真を撮るが好きです</span>", "<span class='hint'>写真が好きです</span>", "<span class='hint'>写真をします</span>"],
+      "correctAnswer": "<span class='hint'>写真を撮るのが好きです</span>",
+      "hints": ["shashin o toru no ga suki desu", "shashin o toru ga suki desu", "shashin ga suki desu", "shashin o shimasu"]
+    },
+    {
+      "id": "hob_gram_3",
+      "category": "Grammatik: Aufzählung (~tari)",
+      "type": "multiple-choice",
+      "questionText": "Was bedeutet der Satz: <span class='hint'>休みの日は、本を読んだり、映画を見たりします</span>。?",
+      "options": [
+        "An freien Tagen tue ich Dinge wie Bücher lesen und Filme schauen.",
+        "An freien Tagen lese ich ein Buch und schaue einen Film.",
+        "An freien Tagen muss ich Bücher lesen und Filme schauen."
+      ],
+      "correctAnswer": "An freien Tagen tue ich Dinge wie Bücher lesen und Filme schauen.",
+      "hints": ["yasumi no hi wa, hon o yondari, eiga o mitari shimasu"]
+    },
+    {
+      "id": "hob_gram_4",
+      "category": "Grammatik: Häufigkeit",
+      "type": "gap-fill",
+      "questionText": "スポーツは <span class='hint'>あまり</span> {blank}。(Ich treibe nicht sehr oft Sport.)",
+      "options": ["しません", "します", "好きです"],
+      "correctAnswer": "しません",
+      "hints": ["amari"]
+    },
+    {
+      "id": "hob_read_1",
+      "category": "Leseverständnis",
+      "type": "reading-comprehension",
+      "questionText": "Was macht Yamada-san <span class='hint'>たいてい</span> (für gewöhnlich) zu Hause an freien Tagen?",
+      "readingTextId": "yamada-text",
+      "options": [
+        "Er/Sie entspannt sich, liest Bücher und hört Musik.",
+        "Er/Sie geht mit Freunden einkaufen.",
+        "Er/Sie treibt Sport.",
+        "Er/Sie putzt das Haus."
+      ],
+      "correctAnswer": "Er/Sie entspannt sich, liest Bücher und hört Musik.",
+      "hints": ["taitei"]
+    },
+    {
+      "id": "hob_read_2",
+      "category": "Leseverständnis",
+      "type": "reading-comprehension",
+      "questionText": "Mag Yamada-san Sport?",
+      "readingTextId": "yamada-text",
+      "options": ["Ja, sehr gerne.", "Nein, nicht besonders.", "Ja, aber nur Tennis."],
+      "correctAnswer": "Nein, nicht besonders."
+    },
+    {
+      "id": "hob_read_3",
+      "category": "Leseverständnis",
+      "type": "reading-comprehension",
+      "questionText": "Was macht Yamada-san <span class='hint'>時々</span> (manchmal)?",
+      "readingTextId": "yamada-text",
+      "options": [
+        "Er/Sie geht mit Freunden einkaufen oder redet im Café.",
+        "Er/Sie schaut Fernsehen.",
+        "Er/Sie entspannt sich zu Hause.",
+        "Er/Sie macht Fotos von Architektur."
+      ],
+      "correctAnswer": "Er/Sie geht mit Freunden einkaufen oder redet im Café.",
+      "hints": ["tokidoki"]
+    }
+  ]
+}

--- a/quiz/german/japanese/invitations.json
+++ b/quiz/german/japanese/invitations.json
@@ -1,0 +1,85 @@
+{
+  "title": "Lehreinheit: Einladungen & Pläne",
+  "description": "Lerne, wie man jemanden höflich zu einer Veranstaltung einlädt, auf Einladungen reagiert und fragt, ob andere Personen teilnehmen.",
+  "cssStyleAdditions": ":root { --primary-color: #8e44ad; --secondary-color: #2980b9; }",
+  "readingTexts": [
+    {
+      "id": "tanaka-suzuki-dialog",
+      "content": "<p class='japanese-text'><b>田中 (たなか):</b> 鈴木 (すずき)さん、今週 (こんしゅう)の土曜日 (どようび)、何か (なにか)予定 (よてい)がありますか？<br><b>鈴木 (すずき):</b> いいえ、特に (とくに)ありません。どうしてですか？<br><b>田中 (たなか):</b> 実は (じつは)、公園 (こうえん)で音楽 (おんがく)フェスティバルがあります。一緒 (いっしょ)に行きませんか？<br><b>鈴木 (すずき):</b> へえ、いいですね！でも、行くかどうか、まだ分かりません。仕事 (しごと)があるかもしれません。<br><b>田中 (たなか):</b> そうですか。もし行けたら、連絡 (れんらく)してください。私は行きます。とても楽しみです。</p>"
+    }
+  ],
+  "questions": [
+    {
+      "id": "inv_vok_1",
+      "category": "Vokabeln",
+      "type": "multiple-choice",
+      "questionText": "Was bedeutet <span class='hint'>試合</span> (しあい)?",
+      "options": ["Übung", "Wettkampf", "Frage", "Fest"],
+      "correctAnswer": "Wettkampf",
+      "hints": ["shiai"]
+    },
+    {
+      "id": "inv_vok_2",
+      "category": "Vokabeln",
+      "type": "multiple-choice",
+      "questionText": "Was bedeutet <span class='hint'>来週</span> (らいしゅう)?",
+      "options": ["Diese Woche", "Nächste Woche", "Letzte Woche", "Jede Woche"],
+      "correctAnswer": "Nächste Woche",
+      "hints": ["raishuu"]
+    },
+    {
+      "id": "inv_gram_1",
+      "category": "Grammatik: Einladung",
+      "type": "multiple-choice",
+      "questionText": "Wie lädt man jemanden höflich ein, zusammen Tee zu trinken? <span class='hint'>一緒にお茶を</span>...",
+      "options": ["<span class='hint'>飲みませんか</span>", "<span class='hint'>飲みましょう</span>", "<span class='hint'>飲みますか</span>"],
+      "correctAnswer": "<span class='hint'>飲みませんか</span>",
+      "hints": ["issho ni ocha o", "nomimasen ka", "nomimashou", "nomimasu ka"]
+    },
+    {
+      "id": "inv_gram_2",
+      "category": "Grammatik: Vorschlag",
+      "type": "multiple-choice",
+      "questionText": "Was bedeutet der Satz: <span class='hint'>練習しましょう</span> (れんしゅうしましょう)?",
+      "options": ["Sollen wir üben?", "Lasst uns üben!", "Ich will üben.", "Ich habe geübt."],
+      "correctAnswer": "Lasst uns üben!",
+      "hints": ["renshuu shimashou"]
+    },
+    {
+      "id": "inv_gram_3",
+      "category": "Grammatik: Unsicherheit",
+      "type": "gap-fill",
+      "questionText": "『<span class='hint'>行く</span> {blank}、<span class='hint'>まだ分かりません</span>。』(Ich weiß noch nicht, ob ich gehe oder nicht.)",
+      "options": ["かどうか", "から", "ので", "と"],
+      "correctAnswer": "かどうか",
+      "hints": ["iku", "mada wakarimasen"]
+    },
+    {
+      "id": "inv_gram_4",
+      "category": "Grammatik: Vorfreude",
+      "type": "multiple-choice",
+      "questionText": "Wie drückst du aus, dass du dich auf das Festival freust?",
+      "options": ["<span class='hint'>楽しみです</span>", "<span class='hint'>大変です</span>", "<span class='hint'>そうですか</span>"],
+      "correctAnswer": "<span class='hint'>楽しみです</span>",
+      "hints": ["tanoshimi desu", "taihen desu", "sou desu ka"]
+    },
+    {
+      "id": "inv_read_1",
+      "category": "Leseverständnis",
+      "type": "reading-comprehension",
+      "questionText": "An welchem Wochentag findet das Musikfestival statt?",
+      "readingTextId": "tanaka-suzuki-dialog",
+      "options": ["Freitag", "Samstag", "Sonntag"],
+      "correctAnswer": "Samstag"
+    },
+    {
+      "id": "inv_read_2",
+      "category": "Leseverständnis",
+      "type": "reading-comprehension",
+      "questionText": "Warum ist Suzuki-san unsicher, ob er/sie mitkommen kann?",
+      "readingTextId": "tanaka-suzuki-dialog",
+      "options": ["Er/Sie mag keine Musik.", "Er/Sie hat vielleicht Arbeit.", "Er/Sie hat kein Geld."],
+      "correctAnswer": "Er/Sie hat vielleicht Arbeit."
+    }
+  ]
+}

--- a/quiz/index.json
+++ b/quiz/index.json
@@ -1,4 +1,7 @@
 [
+  "german/japanese/grammar_drills_complete.json",
+  "german/japanese/hobbies.json",
+  "german/japanese/invitations.json",
   "sample-language.json",
   "sample-math.json",
   "sample-reading.json"

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -2,6 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const quizDir = path.join(__dirname, '..', 'quiz');
-const files = fs.readdirSync(quizDir).filter(f => f.endsWith('.json') && f !== 'index.json');
+const files = [];
+
+function walk(dir, base = '') {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      walk(path.join(dir, entry.name), path.join(base, entry.name));
+    } else if (entry.isFile() && entry.name.endsWith('.json') && entry.name !== 'index.json') {
+      files.push(path.join(base, entry.name).replace(/\\/g, '/'));
+    }
+  }
+}
+
+walk(quizDir);
 fs.writeFileSync(path.join(quizDir, 'index.json'), JSON.stringify(files, null, 2));
 console.log('Generated quiz/index.json with', files.length, 'entries');


### PR DESCRIPTION
## Summary
- support recursive quiz folder traversal in `build-index.js`
- add three German language Japanese quizzes
- regenerate `quiz/index.json`

## Testing
- `node scripts/build-index.js`
- `npm test` *(fails: host system is missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880dce7bd90833185b5eab06b1fcd61